### PR TITLE
Small improvements to builder.Dockerfile

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,8 +1,16 @@
 FROM ghcr.io/initc3/gramine:c04bbae
 
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y libssl-dev gnupg software-properties-common build-essential ca-certificates git
+RUN apt-get update && apt-get install -y \
+                libssl-dev \
+                gnupg \
+                software-properties-common \
+                build-essential \
+                ca-certificates \
+                git \
+    && rm -rf /var/lib/apt/lists/*
+
 
 #install golang
 RUN wget https://go.dev/dl/go1.20.3.linux-amd64.tar.gz


### PR DESCRIPTION
* Best to use ARG than ENV for DEBIAN_FRONTEND noninteractive mode (see https://github.com/moby/moby/issues/4032 and more particularly https://github.com/moby/moby/issues/4032#issuecomment-192327844)
* Clear apt cache to reduce image size (see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)